### PR TITLE
Added the ability to be able to configure the LDAP admin port

### DIFF
--- a/embedded/opendj-embedded-server/src/main/java/org/codice/opendj/embedded/server/LDAPManager.java
+++ b/embedded/opendj-embedded-server/src/main/java/org/codice/opendj/embedded/server/LDAPManager.java
@@ -400,6 +400,15 @@ public class LDAPManager {
                 }
                 setLDAPSPort(newPort);
                 needsRestart = true;
+            } else if (ConnectorType.ADMIN.portVariable.equals(curEntry.getKey())) {
+                int newPort = Integer.parseInt(curEntry.getValue()
+                        .toString());
+                if (newPort == ConnectorType.ADMIN.currentPort) {
+                    logger.debug("Admin Port unchanged, not updating.");
+                    continue;
+                }
+                setAdminPort(newPort);
+                needsRestart = true;
             } else if (BASE_LDIF_STR.equals(curEntry.getKey())) {
                 InputStream ldifStream = null;
                 String ldifLocation = curEntry.getValue()

--- a/embedded/opendj-embedded-server/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/embedded/opendj-embedded-server/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,6 +22,9 @@
         <AD description="Port to listen for LDAPS requests. Set to 0 to disable connector."
             name="LDAPS Port" id="ldaps.port" required="true"
             type="int" default="1636"/>
+        <AD description="Port to listen for Admin requests. Set to 0 to disable connector."
+            name="Admin Port" id="admin.port" required="true"
+            type="int" default="4444"/>
         <AD
                 description="Location to the base LDIF file. This should be used to load a base set of users into the LDAP. NOTE: Changing this will clear out backend before importing."
                 name="Base LDIF File" id="base.ldif" required="true" type="String" default=""/>


### PR DESCRIPTION
Add the ability to be able to configure the admin port in opendj so that it doesn't have to use the default port.
@stustison @coyotesqrl @shaundmorris @roelens8 
