### PR TITLE
DDF-2392 Fixes issue replacing paths in config.ldif on Windows.

### DIFF
--- a/embedded/opendj-embedded-server/src/main/java/org/codice/opendj/embedded/server/LDAPManager.java
+++ b/embedded/opendj-embedded-server/src/main/java/org/codice/opendj/embedded/server/LDAPManager.java
@@ -611,10 +611,10 @@ public class LDAPManager {
      */
     private String updateStore(KeystoreInfo keystoreInfo, String configStr) {
         String newConfig = configStr.trim();
-        newConfig = newConfig.replaceAll(keystoreInfo.locationVar, keystoreInfo.location);
-        newConfig = newConfig.replaceAll(keystoreInfo.passwordVar, keystoreInfo.password);
-        newConfig = newConfig.replaceAll(keystoreInfo.typeVar, keystoreInfo.type);
-        newConfig = newConfig.replaceAll(keystoreInfo.passwordPinVar, keystoreInfo.passwordPin);
+        newConfig = newConfig.replace(keystoreInfo.locationVar, keystoreInfo.location);
+        newConfig = newConfig.replace(keystoreInfo.passwordVar, keystoreInfo.password);
+        newConfig = newConfig.replace(keystoreInfo.typeVar, keystoreInfo.type);
+        newConfig = newConfig.replace(keystoreInfo.passwordPinVar, keystoreInfo.passwordPin);
         return newConfig;
     }
 
@@ -744,12 +744,12 @@ public class LDAPManager {
 
     private enum KeystoreInfo {
 
-        TRUST_STORE(DEFAULT_TRUST_STORE_LOCATION, "trust\\.store\\.loc", DEFAULT_TRUST_STORE_PW,
-                "trust\\.store\\.pw", DEFAULT_TRUST_STORE_PW_LOCACTION, "trust\\.store\\.pin\\.loc",
-                DEFAULT_TRUST_STORE_TYPE, "trust\\.store\\.type"), KEY_STORE(
-                DEFAULT_KEY_STORE_LOCATION, "key\\.store\\.loc", DEFAULT_KEY_STORE_PW,
-                "key\\.store\\.pw", DEFAULT_KEY_STORE_PW_LOCACTION, "key\\.store\\.pin\\.loc",
-                DEFAULT_KEY_STORE_TYPE, "key\\.store\\.type");
+        TRUST_STORE(DEFAULT_TRUST_STORE_LOCATION, "trust.store.loc", DEFAULT_TRUST_STORE_PW,
+                "trust.store.pw", DEFAULT_TRUST_STORE_PW_LOCACTION, "trust.store.pin.loc",
+                DEFAULT_TRUST_STORE_TYPE, "trust.store.type"), KEY_STORE(
+                DEFAULT_KEY_STORE_LOCATION, "key.store.loc", DEFAULT_KEY_STORE_PW,
+                "key.store.pw", DEFAULT_KEY_STORE_PW_LOCACTION, "key.store.pin.loc",
+                DEFAULT_KEY_STORE_TYPE, "key.store.type");
 
         private String location;
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
     <name>Codice OpenDJ</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.slf4j.version>1.7.1</org.slf4j.version>
 
@@ -131,8 +134,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <maxmem>512M</maxmem>
                         <fork>${compiler.fork}</fork>
                         <encoding>${project.build.sourceEncoding}</encoding>


### PR DESCRIPTION
 Also updates the source/target to Java 1.8 as we are using 1.8 features.

We'll want to cut a 1.3.3 release pretty quickly I think.

This should be tested on Windows to hero.

@stustison @jaymcnallie @shaundmorris @Lambeaux 